### PR TITLE
Add missing EXEC helpfiles.

### DIFF
--- a/READ.HELPEXC
+++ b/READ.HELPEXC
@@ -1,0 +1,23 @@
+&READ STATEMENT                                                  EXEC statement
+
+Use the &READ control statement to read information from the terminal and
+process it.  The format of the &READ control statement is:
++-----------+-----------------------------------------------------------------+
+| &READ     | [num]                                                           |
+|           | ARGS                                                            |
+|           | VARS &var1 [&var2 [...]]                                        |
++-----------+-----------------------------------------------------------------+
+where:
+
+num      is a positive integer that indicates the number of lines to read from
+         the terminal and execute.  If the number is not specified, one line is
+         read.
+
+ARGS
+         specifies one line be read from the terminal, tolenized, the tokens
+         assigned to the arguments &1, &2, ..., and the number of tokens be
+         assigned to the special variable &INDEX.
+
+ARGS
+         specifies one line be read from the terminal, tolenized, the tokens
+         assigned to the specified variables.

--- a/SUBSTR.HELPEXC
+++ b/SUBSTR.HELPEXC
@@ -1,0 +1,29 @@
+&SUBSTR FUNCTION                                         EXEC built-in function
+
+Use the &SUBSTR function to extract a substring of a token and assign the
+result to a variable symbol.  The format of the &SUBSTR function is:
++-----------+-----------------------------------------------------------------+
+| &SUBSTR   | token startpos [length]                                         |
++-----------+-----------------------------------------------------------------+
+where:
+
+token
+         specifies the token from which to extract a substring, with a maximum
+         length of eight characters.
+
+startpos
+         specifies the position of the first character to extract, starting at
+         one.
+
+length
+         specifies the number of characters to extract, up to eight.  If not
+         specfied, eight is assumed.
+
+         This function is valid only on the right-hand side of an assignment
+         statement.  For example:
+            &A = ABCDEFGH
+            &B = &SUBSTR &A 2 4
+            &TYPE &B
+
+         results in the printed line:
+            BCDE


### PR DESCRIPTION
The entire suite of EXEC statements and functions is documented in HELP files, except for &READ and &SUBSTR.  After stumbling over &READ VARS for the umpteenth time, I wrote these two files.